### PR TITLE
Cutover: dispatch to dogfood-lab/testing-os

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -150,7 +150,7 @@ jobs:
           echo "Submission built:"
           jq '.run_id, .overall_verdict' /tmp/submission.json
 
-      - name: Dispatch to dogfood-labs
+      - name: Dispatch to testing-os
         env:
           GH_TOKEN: ${{ secrets.DOGFOOD_TOKEN }}
         run: |
@@ -164,7 +164,7 @@ jobs:
 
           jq -n --argjson sub "$SUBMISSION" \
             '{"event_type":"dogfood_submission","client_payload":{"submission":$sub}}' \
-            | gh api repos/mcp-tool-shop-org/dogfood-labs/dispatches \
+            | gh api repos/dogfood-lab/testing-os/dispatches \
               --input - --silent
 
-          echo "Dispatched $RUN_ID to dogfood-labs"
+          echo "Dispatched $RUN_ID to testing-os"


### PR DESCRIPTION
## Summary
- Dispatch the dogfood workflow to `dogfood-lab/testing-os` instead of the legacy `mcp-tool-shop-org/dogfood-labs`.
- Cosmetic: step name + echo strings updated `dogfood-labs` → `testing-os`.

## Why
The dogfood evidence store has been migrated into a new monorepo at https://github.com/dogfood-lab/testing-os (Wave 6 of the testing-os migration). All package code, schemas, swarm control plane, and runtime data dirs are already in the new repo and CI-green. This PR flips the write-path so evidence from this repo lands in the new home.

## Test plan
- [ ] CI passes on this branch (the workflow file change is YAML-only, no logic change)
- [ ] Once merged, the next dogfood run from this repo successfully dispatches to `dogfood-lab/testing-os` (verify via the next push that triggers `.github/workflows/dogfood.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)