### PR TITLE
chore: bump GH Actions to Node 24-compatible releases (extended)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: site
         run: npm run build
 
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site/dist
 


### PR DESCRIPTION
Mechanical extension to the original Node 24 sweep — covers the actions/* that the first pass missed (setup-python, upload-pages-artifact, deploy-pages, configure-pages, setup-dotnet, attest-build-provenance, dependency-review-action).

GitHub forces Node 24 default on Jun 2, 2026 and removes Node 20 entirely on Sep 16, 2026.

**Bumps:**
- `actions/setup-python` v5 → v6.2.0 (`a309ff8b426b58ec0e2a45f0f869d46889d02405`)
- `actions/upload-pages-artifact` v3/v4 → v5.0.0 (`fc324d3547104276b827a68afc52ff2a11cc49c9`)
- `actions/deploy-pages` v4 → v5.0.0 (`cd2ce8fcbc39b97be8ca5fce6e763baed58fa128`)
- `actions/configure-pages` → v6.0.0 (`45bfe0192ca1faeb007ade9deae92b16b8254a0d`)
- `actions/setup-dotnet` v4 → v5.2.0 (`c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7`)
- `actions/attest-build-provenance` v1 → v4.1.0 (`a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32`)
- `actions/dependency-review-action` v4 → v5.0.0 (`a1d282b36b6f3519aa1f3fc636f609c47dddb294`)

**Breaking-change audit:**
- `upload-pages-artifact` v4 (and onward): hidden dotfiles excluded from artifact by default. `_astro/` is unaffected (underscore prefix, not dot). `.well-known/` would be — check if your site publishes one.
- `attest-build-provenance` v2: multi-subject attestation became single attestation per call. Backward-compatible for typical single-subject usage.
- Runner version: requires v2.327.1+; GitHub-hosted runners auto-update.

SHA + version-comment pinning preserved.